### PR TITLE
Laravel 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 .phpunit.result.cache
 config.php
 index.php
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
   },
   "require": {
     "nikic/php-parser": "^4.10.3",
-    "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0"
+    "laravel/framework": "^10.0 || ^11.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5 || ^9.0",
-    "orchestra/testbench": "^5.0 || ^6.0",
+    "phpunit/phpunit": "^10.0",
+    "orchestra/testbench": "^8.0 || ^9.0",
     "laravel/pint": "^1.6"
   },
   "extra": {

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,29 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <php>
-        <ini name="xdebug.mode" value="coverage" />
-        <env name="XDEBUG_MODE" value="coverage" />
-    </php>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Proteus Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <php>
+    <ini name="xdebug.mode" value="coverage"/>
+    <env name="XDEBUG_MODE" value="coverage"/>
+  </php>
+  <testsuites>
+    <testsuite name="Proteus Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
This pull request adds Laravel 11 support to Proteus. 

It also also drops support for older versions of Laravel - the minimum supported version is now Laravel 10, as per [the Laravel support policy](https://laravel.com/docs/master/releases#support-policy).

This PR also migrates to PHPUnit 10.

Closes #30.