### PR TITLE
Set types properly

### DIFF
--- a/src/Writers/FunctionWriter.php
+++ b/src/Writers/FunctionWriter.php
@@ -107,7 +107,7 @@ class FunctionWriter
 
     private function arg(mixed $arg): Arg
     {
-        $scalarClass = $this->getScalarClass($arg);
+        $scalarClass = $this->getScalarClass(gettype($arg));
 
         return new Arg(new $scalarClass($arg));
     }

--- a/src/Writers/FunctionWriter.php
+++ b/src/Writers/FunctionWriter.php
@@ -96,7 +96,7 @@ class FunctionWriter
         return new Name($name);
     }
 
-    private function getScalarClass(string $type): string
+    private function scalarClass(string $type): string
     {
         return match ($type) {
             'integer' => Int_::class,
@@ -107,7 +107,7 @@ class FunctionWriter
 
     private function arg(mixed $arg): Arg
     {
-        $scalarClass = $this->getScalarClass(gettype($arg));
+        $scalarClass = $this->scalarClass(gettype($arg));
 
         return new Arg(new $scalarClass($arg));
     }

--- a/src/Writers/FunctionWriter.php
+++ b/src/Writers/FunctionWriter.php
@@ -6,6 +6,8 @@ use Closure;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Float_;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 
 class FunctionWriter
@@ -85,12 +87,28 @@ class FunctionWriter
     {
         return collect($args)
             ->reject(fn ($arg) => $arg === null || mb_strlen($arg) === 0)
-            ->map(fn (string $arg) => new Arg(new String_($arg)))
+            ->map(fn (mixed $arg) => $this->arg($arg))
             ->all();
     }
 
     private function convertToName(string $name)
     {
         return new Name($name);
+    }
+
+    private function getScalarClass(string $type): string
+    {
+        return match ($type) {
+            'integer' => Int_::class,
+            'double' => Float_::class,
+            default => String_::class,
+        };
+    }
+
+    private function arg(mixed $arg): Arg
+    {
+        $scalarClass = $this->getScalarClass($arg);
+
+        return new Arg(new $scalarClass($arg));
     }
 }

--- a/src/Writers/FunctionWriter.php
+++ b/src/Writers/FunctionWriter.php
@@ -4,6 +4,7 @@ namespace Stillat\Proteus\Writers;
 
 use Closure;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Float_;
@@ -86,7 +87,7 @@ class FunctionWriter
     private function convertToArgs($args)
     {
         return collect($args)
-            ->reject(fn ($arg) => $arg === null || mb_strlen($arg) === 0)
+            ->reject(fn ($arg) => $arg === null || (is_string($arg) && mb_strlen($arg) === 0))
             ->map(fn (mixed $arg) => $this->arg($arg))
             ->all();
     }
@@ -107,6 +108,10 @@ class FunctionWriter
 
     private function arg(mixed $arg): Arg
     {
+        if (is_bool($arg)) {
+            return new Arg(new ConstFetch(new Name($arg ? 'true' : 'false')));
+        }
+
         $scalarClass = $this->scalarClass(gettype($arg));
 
         return new Arg(new $scalarClass($arg));

--- a/tests/LaravelFunctionCallTest.php
+++ b/tests/LaravelFunctionCallTest.php
@@ -60,8 +60,6 @@ class LaravelFunctionCallTest extends ProteusTestCase
         );
     }
 
-
-
     public function testWritingNewClosuresOrArrowFunctions()
     {
         $f = new FunctionWriter();

--- a/tests/LaravelFunctionCallTest.php
+++ b/tests/LaravelFunctionCallTest.php
@@ -60,6 +60,21 @@ class LaravelFunctionCallTest extends ProteusTestCase
         );
     }
 
+    public function testTypesAreMaintained()
+    {
+        $f = new FunctionWriter;
+
+        $this->assertChangeEquals(
+            __DIR__.'/configs/empty.php',
+            __DIR__.'/expected/typesenv.php',
+            [
+                'int_type' => $f->env('INTEGER_TYPE', 5),
+                'double_type' => $f->env('DOUBLE_TYPE', 5.0),
+                'string_type' => $f->env('STRING_TYPE', '5'),
+            ]
+        );
+    }
+
     public function testWritingNewClosuresOrArrowFunctions()
     {
         $f = new FunctionWriter();

--- a/tests/LaravelFunctionCallTest.php
+++ b/tests/LaravelFunctionCallTest.php
@@ -71,6 +71,8 @@ class LaravelFunctionCallTest extends ProteusTestCase
                 'int_type' => $f->env('INTEGER_TYPE', 5),
                 'double_type' => $f->env('DOUBLE_TYPE', 5.0),
                 'string_type' => $f->env('STRING_TYPE', '5'),
+                'bool_true' => $f->env('BOOL_TRUE', true),
+                'bool_false' => $f->env('BOOL_FALSE', false),
             ]
         );
     }

--- a/tests/expected/typesenv.php
+++ b/tests/expected/typesenv.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'int_type' => env('INTEGER_TYPE', 5),
+    'double_type' => env('DOUBLE_TYPE', 5.0),
+    'string_type' => env('STRING_TYPE', '5'),
+];

--- a/tests/expected/typesenv.php
+++ b/tests/expected/typesenv.php
@@ -4,4 +4,6 @@ return [
     'int_type' => env('INTEGER_TYPE', 5),
     'double_type' => env('DOUBLE_TYPE', 5.0),
     'string_type' => env('STRING_TYPE', '5'),
+    'bool_true' => env('BOOL_TRUE', true),
+    'bool_false' => env('BOOL_FALSE', false),
 ];


### PR DESCRIPTION
All parameters passed to functions in the writer were strings, instead of maintaining their original type.