### PR TITLE
Fix function call replacing

### DIFF
--- a/src/Analyzers/ConfigAnalyzer.php
+++ b/src/Analyzers/ConfigAnalyzer.php
@@ -363,6 +363,12 @@ class ConfigAnalyzer
 
                 return;
             } elseif ($currentNode->value instanceof FuncCall) {
+                if ($node instanceof FuncCall) {
+                    $currentNode->value = $node;
+
+                    return;
+                }
+
                 if ($this->shouldProceedWithFunctionRewrite($key, $currentCheckValue)) {
                     $this->functionHandler->handle($currentNode->value, $currentNode, $node, $key);
                 }

--- a/src/LaravelConfigWriter.php
+++ b/src/LaravelConfigWriter.php
@@ -432,6 +432,7 @@ class LaravelConfigWriter implements ConfigWriterContract
         }
 
         $configUpdater = new ConfigUpdater();
+        $configUpdater->setIgnoreFunctions($this->ignoreFunctions);
         $configUpdater->open($file);
 
         return $configUpdater;

--- a/tests/FuncCallReplacementTest.php
+++ b/tests/FuncCallReplacementTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Stillat\Proteus\Tests;
+
+use ReflectionObject;
+use Stillat\Proteus\ConfigUpdater;
+use Stillat\Proteus\Document\Transformer;
+use Stillat\Proteus\LaravelConfigWriter;
+use Stillat\Proteus\Writers\FunctionWriter;
+
+class FuncCallReplacementTest extends ProteusTestCase
+{
+    /**
+     * Replacing one FuncCall with a different FuncCall should work with the
+     * default ignoreFunctions=true, since the caller is making an explicit
+     * replacement (not a bulk update where function preservation makes sense).
+     */
+    public function testReplacingExistingFuncCallWithDifferentFuncCall(): void
+    {
+        $f = new FunctionWriter();
+
+        $updater = new ConfigUpdater(); // ignoreFunctions=true by default
+        $updater->open(__DIR__.'/configs/funcall_replacement.php');
+        $updater->update(['path' => $f->basePath('content/revisions')]);
+
+        $expected = Transformer::normalizeLineEndings(
+            file_get_contents(__DIR__.'/expected/funcall_replacement.php')
+        );
+
+        $this->assertEquals($expected, $updater->getDocument());
+    }
+
+    /**
+     * LaravelConfigWriter::getUpdater() must propagate the ignoreFunctions
+     * setting to the ConfigUpdater it creates, so that
+     * ConfigWriter::ignoreFunctionCalls(false) actually takes effect when
+     * going through the edit()->set()->save() path.
+     */
+    public function testGetUpdaterPassesIgnoreFunctionsToConfigUpdater(): void
+    {
+        // Copy the fixture before constructing LaravelConfigWriter — it scans configPath() on construction.
+        $configPath = $this->app->configPath();
+        $fixture = $configPath.'/funcall_replacement.php';
+        copy(__DIR__.'/configs/funcall_replacement.php', $fixture);
+
+        try {
+            $writer = new LaravelConfigWriter($this->app, $this->app['config']);
+            $writer->ignoreFunctionCalls(false);
+
+            $updater = $writer->getUpdater('funcall_replacement');
+
+            $updaterRef = new ReflectionObject($updater);
+            $updaterProp = $updaterRef->getProperty('ignoreFunctions');
+
+            $this->assertFalse(
+                $updaterProp->getValue($updater),
+                'getUpdater() should propagate ignoreFunctions=false to the returned ConfigUpdater'
+            );
+        } finally {
+            @unlink($fixture);
+        }
+    }
+}

--- a/tests/configs/funcall_replacement.php
+++ b/tests/configs/funcall_replacement.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'path' => storage_path('revisions'),
+];

--- a/tests/expected/funcall_replacement.php
+++ b/tests/expected/funcall_replacement.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'path' => base_path('content/revisions'),
+];


### PR DESCRIPTION
I was trying to edit a config file that had:

```
'path' => storage_path('revisions'),
```

And it didn't work.

This is the solution proposed by Claude, I had it write failing tests first.